### PR TITLE
Update socket lib & reduce log noise

### DIFF
--- a/cmd/internal/setup.go
+++ b/cmd/internal/setup.go
@@ -70,13 +70,17 @@ func SetupDeps(cfg config.Config, l log.Logger) *Deps {
 }
 
 // SetupEcho will set up and return an echo server.
-func SetupEcho(l log.Logger) *echo.Echo {
+func SetupEcho(cfg *config.Config, l log.Logger) *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 
 	// Middleware
 	e.Use(middleware.Recover())
-	e.Use(middleware.Logger())
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Skipper: func(c echo.Context) bool {
+			return cfg.Logging.Level != config.LogDebug
+		},
+	}))
 	e.Use(middleware.RequestID())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},

--- a/cmd/internal/setup.go
+++ b/cmd/internal/setup.go
@@ -143,8 +143,6 @@ func SetupHybrid(cfg config.Config, l log.Logger, e *echo.Echo) *server.SocketSe
 	dppHandlers.NewPaymentRequestHandler(paymentReqSvc).RegisterRoutes(g)
 	dppHandlers.NewProofs(proofsSvc).RegisterRoutes(g)
 	dppSoc.NewHealthHandler().Register(s)
-	dppSoc.NewPaymentRequest().Register(s)
-	dppSoc.NewPayment().Register(s)
 
 	e.GET("/ws/:channelID", wsHandler(s))
 	return s

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -57,7 +57,7 @@ func main() {
 		log.Fatal(err, "config error")
 	}
 
-	e := internal.SetupEcho(log)
+	e := internal.SetupEcho(cfg,log)
 
 	if cfg.Server.SwaggerEnabled {
 		internal.SetupSwagger(*cfg.Server, e)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/swaggo/swag v1.8.1
 	github.com/theflyingcodr/govalidator v0.1.3
 	github.com/theflyingcodr/lathos v0.0.6
-	github.com/theflyingcodr/sockets v0.0.11-beta.0.20220222160101-76100ef886b5
+	github.com/theflyingcodr/sockets v0.0.12-beta
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -231,7 +231,6 @@ github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/Oth
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -292,7 +291,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo/v4 v4.1.14/go.mod h1:Q5KZ1vD3V5FEzjM79hjwVrC3ABr7F5IdM23bXQMRDGg=
-github.com/labstack/echo/v4 v4.6.3/go.mod h1:Hk5OiHj0kDqmFq7aHe7eDqI7CUhuCrfpupQtLGGLm7A=
 github.com/labstack/echo/v4 v4.7.2 h1:Kv2/p8OaQ+M6Ex4eGimg9b9e6icoxA42JSlOR3msKtI=
 github.com/labstack/echo/v4 v4.7.2/go.mod h1:xkCDAdFCIf8jsFQ5NnbK7oqaF/yU1A1X20Ltm0OvSks=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
@@ -449,8 +447,8 @@ github.com/theflyingcodr/govalidator v0.1.3 h1:eU8P2xZrU2s1FjbtoVW6yDgXG+g2xDM9p
 github.com/theflyingcodr/govalidator v0.1.3/go.mod h1:E6v0mkRcAVMTa7pC8VkUOtoE8WQ9zQ4/fOwrvtwhOM0=
 github.com/theflyingcodr/lathos v0.0.6 h1:xIHMZTinurvodmFOgvSGD+OrDhSj42+Xz+FOXYwEr18=
 github.com/theflyingcodr/lathos v0.0.6/go.mod h1:68tGFEbAqAzydWDb1KEJZPQY57l3hH32GXO11Hf1zGQ=
-github.com/theflyingcodr/sockets v0.0.11-beta.0.20220222160101-76100ef886b5 h1:39/z+O7p2ND6GgvOHZAr7o1gjm6UGls8FCcki8hbXRE=
-github.com/theflyingcodr/sockets v0.0.11-beta.0.20220222160101-76100ef886b5/go.mod h1:u4PMKd3yqHkt9Jn0VgQRZ33PG9ynL8/j53csVO1huyk=
+github.com/theflyingcodr/sockets v0.0.12-beta h1:5x6+7rQtVN0bEhaWdRm10MMvYdp0DPbHe5sB40DlVBk=
+github.com/theflyingcodr/sockets v0.0.12-beta/go.mod h1:lEfw9IoVkWJsuvi5ja5QuusFjfVvpocaJl0RP7iFLRY=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -577,7 +575,6 @@ golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=

--- a/vendor/github.com/theflyingcodr/sockets/Makefile
+++ b/vendor/github.com/theflyingcodr/sockets/Makefile
@@ -27,7 +27,7 @@ run-linter:
 	@golangci-lint run --deadline=480s --skip-dirs=vendor --tests
 
 install-linter:
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)bin v1.43.0
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)bin v1.44.2
 
 go-doc-mac:
 	@open http://localhost:6060 && \

--- a/vendor/github.com/theflyingcodr/sockets/internal/sockets.go
+++ b/vendor/github.com/theflyingcodr/sockets/internal/sockets.go
@@ -17,3 +17,9 @@ func WriteJSON(ws *websocket.Conn, timeout time.Duration, payload interface{}) e
 	_ = ws.SetWriteDeadline(time.Now().Add(timeout))
 	return ws.WriteJSON(payload)
 }
+
+// ChannelCheck for sending channel check messages.
+type ChannelCheck struct {
+	ID     string
+	Exists chan bool
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -198,7 +198,7 @@ github.com/theflyingcodr/govalidator
 ## explicit; go 1.17
 github.com/theflyingcodr/lathos
 github.com/theflyingcodr/lathos/errs
-# github.com/theflyingcodr/sockets v0.0.11-beta.0.20220222160101-76100ef886b5
+# github.com/theflyingcodr/sockets v0.0.12-beta
 ## explicit; go 1.17
 github.com/theflyingcodr/sockets
 github.com/theflyingcodr/sockets/internal


### PR DESCRIPTION
Updates the socket lib to a version that uses debug logs rather than info logs, results in much less noise in logs and easier debugging errors.

Reduce log noise for echo logger, now only outputs on debug mode.